### PR TITLE
Fix Default Values in Authentication Factory

### DIFF
--- a/src/Authenticator/AuthenticationFactory.php
+++ b/src/Authenticator/AuthenticationFactory.php
@@ -10,8 +10,8 @@
 
     public function __construct(
       PardotApi $api, string $authType, string $email, string $password, string $userApiSecurityToken,
-      string $userKey = null, string $businessUnitId = null, string $consumerKey = null,
-      string $consumerSecret = null
+      string $userKey = '', string $businessUnitId = '', string $consumerKey = '',
+      string $consumerSecret = ''
     )
     {
       $this->api = $api;


### PR DESCRIPTION
null default values are incompatible with the string typehint and will throw errors in certain situations